### PR TITLE
Rename images.openshift-cli to openshiftCli

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -28,7 +28,3 @@ function exported_or_fail() {
     return 0
 }
 
-
-
-
-

--- a/scripts/oc-client.sh
+++ b/scripts/oc-client.sh
@@ -15,10 +15,3 @@ export KUBECONFIG=$(workspaces.kubeconfig_dir.path)/kubeconfig
 
 "${params.SCRIPT}"
 
-
-
-
-
-
-
-

--- a/scripts/oc-common.sh
+++ b/scripts/oc-common.sh
@@ -18,8 +18,3 @@ exported_or_fail \
     WORKSPACES_KUBECONFIG_DIR_PATH \
     PARAMS_SCRIPT \
     PARAMS_VERSION
-
-
-
-
-

--- a/templates/task-openshift-client.yaml
+++ b/templates/task-openshift-client.yaml
@@ -54,7 +54,7 @@ spec:
 {{- include "load_scripts" ( list . "oc-" ) | nindent 4 }}
 
     - name: oc
-      image: {{ .Values.images.openshift-cli }}
+      image: {{ .Values.images.openshiftCli }}
       env:
         - name: HOME
           value: /tekton/home
@@ -66,12 +66,8 @@ spec:
       volumeMounts:
         - name: scripts-dir
           mountPath: /scripts
-  
+
   volumes:
     - name: scripts-dir
       emptyDir: {}
-
-
-
-
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 ---
 images:
   bash: registry.access.redhat.com/ubi8-minimal:latest
-  openshift-cli: registry.redhat.io/openshift3/ose-cli
+  openshiftCli: registry.redhat.io/openshift3/ose-cli
 
 annotations:
   tekton.dev/pipelines.minVersion: "0.17.0"


### PR DESCRIPTION
The dash `-` in the name is not supported by helm, so we need to
rename it (using camelCase for example)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
