### PR TITLE
Revert "Update builder images to ubi9/rhel9"

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 ---
 images:
-  bash: registry.access.redhat.com/ubi9-minimal:latest
-  openshiftCli: registry.redhat.io/openshift4/ose-cli@sha256:4257542c6e7343abd048f8b1c1e06afeed8d4e4bfafe8621fcfa32b92c77b644
+  bash: registry.access.redhat.com/ubi8-minimal:latest
+  openshiftCli: registry.redhat.io/openshift4/ose-cli@sha256:3d5b31cc3fbf878015e5c3ed1d48379d74b15b77a1a823024a7a2b7cd5e2e86d
   tkn: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:72394dfaed68c4b6b490c3c971fb1d9f0139f8656f6672b55b8e02ea98d1298d
   kn: registry.redhat.io/openshift-serverless-1/client-kn-rhel8:1.11.2-4
   opc: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/ecosystem-images/opc-ecosystem-images@sha256:97ba3f5cb6d20609de1133ea6e176884f103222b59fa8155190d3b95e7f5f43a    


### PR DESCRIPTION
This reverts commit 63f9cdde80564933c31ee67ff6d70fa316ea2d70.