### PR TITLE
openshift-client: eval PARAMS_SCRIPT

### DIFF
--- a/scripts/oc-client.sh
+++ b/scripts/oc-client.sh
@@ -13,5 +13,5 @@ source "$(dirname ${BASH_SOURCE[0]})/oc-common.sh"
 [[ -f ${WORKSPACES_KUBECONFIG_DIR_PATH}/kubeconfig ]] && \
 export KUBECONFIG=${WORKSPACES_KUBECONFIG_DIR_PATH}/kubeconfig
 
-${PARAMS_SCRIPT}
+eval "${PARAMS_SCRIPT}"
 


### PR DESCRIPTION
If we do not eval, things like `cat << EOF | …` will fail.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
