### PR TITLE
docs: add working example for opc task

### DIFF
--- a/docs/task-opc.md
+++ b/docs/task-opc.md
@@ -24,6 +24,61 @@ spec:
       value: opc-command-you-want-to-execute
 
 ```
+
+## Working Example
+
+Here's a complete working example that uses the `opc` task to list pipelines:
+
+**Pipeline:**
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: opc-task-pipeline
+spec:
+  tasks:
+    - name: opc-pipeline-list
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: opc
+          - name: namespace
+            value: openshift-pipelines
+      params:
+        - name: SCRIPT
+          value: "opc $@"
+        - name: ARGS
+          value:
+            - pipeline
+            - list
+            - -n
+            - $(context.pipelineRun.namespace)
+```
+
+**PipelineRun:**
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: opc-task-run
+spec:
+  pipelineRef:
+    name: opc-task-pipeline
+```
+
+**Output:**
+
+```
+[opc-pipeline-list : opc] Running Script /scripts/opc-client.sh
+[opc-pipeline-list : opc] NAME                AGE              LAST RUN       STARTED         DURATION   STATUS
+[opc-pipeline-list : opc] opc-task-pipeline   15 minutes ago   opc-task-run   5 seconds ago   ---        Running
+```
+
 You'll need to replace `opc-command-you-want-to-execute`  with opc CLI arguments based on what operation you want to perform with the Tekton resources in OpenShift Pipelines.
 In case the Container Registry requires authentication, please consider the [Tekton Pipelines documentation][tektonPipelineAuth]. In a nutshell, you need to create a Kubernetes Secret describing the following attributes:
 


### PR DESCRIPTION
Added Pipeline and PipelineRun example demonstrating how to use the opc task to list pipelines in the current namespace.